### PR TITLE
Specify assistant role in GPT-OSS conversation rendering

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gpt_oss.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gpt_oss.py
@@ -431,7 +431,8 @@ class GPTOSSHandler(OSSHandler):
         conversation = self._build_conversation(message, tools)
 
         conversation_tokens = self.harmony_encoding.render_conversation_for_completion(
-            conversation
+            conversation=conversation,
+            next_turn_role=Role.ASSISTANT,
         )
         inference_data["inference_input_log"] = {"prompt": conversation_tokens}
 


### PR DESCRIPTION
## Summary
- Pass assistant role to `render_conversation_for_completion` in GPT-OSS handler to match API signature

## Testing
- `pytest berkeley-function-call-leaderboard/bfcl_eval`
- `bfcl generate --model gpt-oss-20b --test-category simple_python --num-threads 1 --skip-server-setup` *(fails: Failed to load Harmony encoding: error downloading or loading vocab file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc875acce08325ab6bee8538c59714