### PR TITLE
Decode GPT-OSS FC prompts to string before sending requests

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gpt_oss.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gpt_oss.py
@@ -434,7 +434,8 @@ class GPTOSSHandler(OSSHandler):
             conversation=conversation,
             next_turn_role=Role.ASSISTANT,
         )
-        inference_data["inference_input_log"] = {"prompt": conversation_tokens}
+        prompt = self.harmony_encoding.decode_utf8(conversation_tokens)
+        inference_data["inference_input_log"] = {"prompt": prompt}
 
         input_token_count = len(conversation_tokens)
         if self.max_context_length < input_token_count + 2:
@@ -446,7 +447,7 @@ class GPTOSSHandler(OSSHandler):
 
         payload = {
             "model": self.model_path_or_id,
-            "input": conversation_tokens,
+            "input": prompt,
             "temperature": self.temperature,
             "max_output_tokens": leftover_tokens_count,
         }


### PR DESCRIPTION
## Summary
- Decode Harmony token lists to UTF-8 prompt strings in GPT-OSS function calling
- Send string prompt in `/responses` payload while keeping temperature and max_output_tokens top-level

## Testing
- `pytest -q`
- `curl -i -X POST http://localhost:1053/v1/responses -H 'Content-Type: application/json' -d '{"model":"dummy","input":"hi"}'` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8993e92083259bb9dc4560effc0c