### PR TITLE
Use Harmony namespace mapping for GPT-OSS tools

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gpt_oss.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gpt_oss.py
@@ -91,8 +91,8 @@ class GPTOSSHandler(OSSHandler):
         system_content = SystemContent.new()
 
         # Add tools if available
-        for ns in harmony_tools.values():
-            system_content = system_content.with_tools(ns)
+        if harmony_tools:
+            system_content = system_content.with_tools(harmony_tools)
 
         # Add conversation start date
         system_content = system_content.with_conversation_start_date(
@@ -380,8 +380,8 @@ class GPTOSSHandler(OSSHandler):
         system_content = SystemContent.new().with_conversation_start_date(
             datetime.now().strftime("%Y-%m-%d")
         )
-        for ns in tools.values():
-            system_content = system_content.with_tools(ns)
+        if tools:
+            system_content = system_content.with_tools(tools)
 
         harmony_messages: List[Message] = [
             Message.from_role_and_content(Role.SYSTEM, system_content)


### PR DESCRIPTION
## Summary
- build namespace mapping for BFCL functions and return {namespace.name: namespace}
- pass tool namespace mapping directly to SystemContent.with_tools

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c30119c83259d92edbbff99069d