### PR TITLE
Use CLI model name for GPT-OSS

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gpt_oss.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gpt_oss.py
@@ -40,6 +40,13 @@ class GPTOSSHandler(OSSHandler):
     """
 
     def __init__(self, model_name, temperature) -> None:
+        # GPT-OSS models on HuggingFace are namespaced under "openai/".
+        # If the user provides the shorthand id (e.g. "gpt-oss-20b"),
+        # automatically expand it to include the prefix so that subsequent
+        # requests use the fully-qualified model name.
+        if not model_name.startswith("openai/"):
+            model_name = f"openai/{model_name}"
+
         super().__init__(model_name, temperature)
         self.is_fc_model = True
         self.model_style = ModelStyle.OSSMODEL
@@ -446,7 +453,11 @@ class GPTOSSHandler(OSSHandler):
             )
 
         payload = {
-            "model": self.model_path_or_id,
+            # Use the model identifier supplied via the CLI argument. This
+            # allows callers to specify either fully-qualified names such as
+            # "openai/gpt-oss-20b" or rely on the automatic prefix expansion
+            # performed during initialisation.
+            "model": self.model_name,
             "input": prompt,
             "temperature": self.temperature,
             "max_output_tokens": leftover_tokens_count,


### PR DESCRIPTION
## Summary
- default GPT-OSS handler to the fully qualified OpenAI model id when shorthand is provided
- send the CLI-supplied model name in local inference requests

## Testing
- `pytest`
- `python -m bfcl_eval.__main__ generate --model gpt-oss-20b --test-category simple_python --skip-server-setup --num-threads 1 --temperature 0` *(fails: RuntimeError: Failed to load Harmony encoding: error downloading or loading vocab file)*
- `curl -s -X POST http://localhost:1053/v1/responses -H 'Content-Type: application/json' -d '{"model":"openai/gpt-oss-20b","input":"hi"}'`

------
https://chatgpt.com/codex/tasks/task_e_68bc8d8a5b04832581978a4147a52e27